### PR TITLE
docs: auto release version in docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,10 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+# -- metadata import
+
+import importlib.metadata
+
 # -- Project information -----------------------------------------------------
 
 project = "pretty-toml-sort"
@@ -23,7 +27,8 @@ copyright = "2019, Samuel Roeca; 2024-preset Christopher J. Brody"  # pylint: di
 author = "Samuel Roeca"
 
 # The full version, including alpha/beta/rc tags
-release = "0.17.0"
+# (from the metadata)
+release = importlib.metadata.version('pretty-toml-sort')
 
 # -- General configuration ---------------------------------------------------
 master_doc = "index"


### PR DESCRIPTION
use correct release version as specified in `pyproject.toml` - similar to solution in PR #6

see also:

- https://stackoverflow.com/questions/67085041/how-to-specify-version-in-only-one-place-when-using-pyproject-toml/67097076#67097076 - many thanks!
- https://docs.python.org/3/library/importlib.metadata.html