### PR TITLE
ci: lint with Python 3.11

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Select Python 3.10
+      - name: Select Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           architecture: x64
 
       - name: Install Dependencies


### PR DESCRIPTION
Holding off on Python 3.12 for now to avoid issue with Pylint