### PR TITLE
ci: coverage test with Python 3.12

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -75,10 +75,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Select Python 3.10
+      - name: Select Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           architecture: x64
 
       - name: Install Dependencies


### PR DESCRIPTION
(should have been done with PR #4, catching up now)